### PR TITLE
Bug: New activities do not show the detailed content in full width

### DIFF
--- a/components/ActivityDetail/ActivityDetail.styles.js
+++ b/components/ActivityDetail/ActivityDetail.styles.js
@@ -17,7 +17,8 @@ export const Card = styled.article`
 `;
 
 export const ImageArea = styled.div`
-  height: 300px;
+  height: 400px;
+  width: 100vw;
   overflow: hidden;
   position: relative;
 


### PR DESCRIPTION
The image is now display in full-width on details page